### PR TITLE
Fix typo in output format validation message

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ def build_sanjuuni(src: str, out: str, *,
     if dithering not in ["threshold","ordered","lab-color","octree","kmeans","none"]:
       raise ValueError("dithering not in threshold, ordered, lab-color, octree, kmeans, none")
     if output not in ["bimg","nfp"]:
-      raise ValueError("dithering not in bimg, nfp")
+      raise ValueError("output not in bimg, nfp")
     
     builder = "sanjuuni {fmt} {dither} {pal} {h} {w} {b} {palette} --input {src} -o {out}"
     dither = ({


### PR DESCRIPTION
This caused me some confusion when sending requests, as the error references dithering when it was really output that was incorrect.